### PR TITLE
[RDV-2211] strict version aws-sdk/signature-v4-crt

### DIFF
--- a/packages/s3-deploy/package.json
+++ b/packages/s3-deploy/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.54.0",
-    "@aws-sdk/signature-v4-crt": "^3.272.0",
+    "@aws-sdk/signature-v4-crt": "3.272.0",
     "@radicalimaging/static-wado-plugins": "^0.6.1",
     "@radicalimaging/static-wado-util": "^0.6.1",
     "aws-cdk-lib": "^2.90.0",


### PR DESCRIPTION
New version of aws-sdk library requires node version 18.x which breaks dicomwebscp feature.